### PR TITLE
Bugfix: app crashes when trying to set up Telegram notifications

### DIFF
--- a/src/notifiers/telegram.py
+++ b/src/notifiers/telegram.py
@@ -108,14 +108,15 @@ class Telegram():
         while not self.chat_ids:
             updates = self.updater.bot.get_updates(timeout=60)
             for update in reversed(updates):
-                if int(update.message.text) == code:
-                    log.warning(
+                if update.message and update.message.text:
+                    if update.message.text.isdecimal() and int(update.message.text) == code:
+                        log.warning(
                         "Received code from %s %s on chat id %s",
                         update.message.from_user.first_name,
                         update.message.from_user.last_name,
                         update.message.chat_id
-                    )
-                    self.chat_ids = [str(update.message.chat_id)]
+                        )
+                        self.chat_ids = [str(update.message.chat_id)]
             sleep(1)
         if self.config.set("TELEGRAM", "chat_ids", ','.join(self.chat_ids)):
             log.warning("Saved chat id in your config file")


### PR DESCRIPTION
This PR fixes a bug in setting up telegram notifications. The app crashes since `message` as well as `message.text` are [optional](https://docs.python-telegram-bot.org/en/v20.0a2/telegram.update.html#telegram.Update.params.message) [fields](https://docs.python-telegram-bot.org/en/v20.0a2/telegram.message.html#telegram.Message.params.text).

```
app_1  | 2022-07-08 21:43:08 INFO       ____  ___  ____  ___    ____   ___   __   __ _  __ _  ____  ____  
app_1  | 2022-07-08 21:43:08 INFO      (_  _)/ __)(_  _)/ __)  / ___) / __) / _\ (  ( \(  ( \(  __)(  _ \ 
app_1  | 2022-07-08 21:43:08 INFO        )( ( (_ \  )( ( (_ \  \___ \( (__ /    \/    //    / ) _)  )   / 
app_1  | 2022-07-08 21:43:08 INFO       (__) \___/ (__) \___/  (____/ \___)\_/\_/\_)__)\_)__)(____)(__\_) 
app_1  | 2022-07-08 21:43:08 INFO     
app_1  | 2022-07-08 21:43:08 INFO     Version 1.11.1_rc1
app_1  | 2022-07-08 21:43:08 INFO     ©2021, Henning Merklinger
app_1  | 2022-07-08 21:43:08 INFO     For documentation and support please visit https://github.com/Der-Henning/tgtg
app_1  | 2022-07-08 21:43:08 INFO     
app_1  | 2022-07-08 21:43:08 INFO     Loaded config from environment variables
app_1  | 2022-07-08 21:43:09 WARNING  You enabled the Telegram notifications without providing a chat id!
app_1  | 2022-07-08 21:43:09 WARNING  Send 8746 to the bot in your desired chat.
app_1  | 2022-07-08 21:43:09 WARNING  Waiting for code ...
app_1  | Traceback (most recent call last):
app_1  |   File "/app/scanner.py", line 243, in <module>
app_1  |     main()
app_1  |   File "/app/scanner.py", line 228, in main
app_1  |     scanner = Scanner()
app_1  |   File "/app/scanner.py", line 73, in __init__
app_1  |     self.notifiers = Notifiers(self.config)
app_1  |   File "/app/notifiers/__init__.py", line 18, in __init__
app_1  |     self.telegram = Telegram(config)
app_1  |   File "/app/notifiers/telegram.py", line 38, in __init__
app_1  |     self._get_chat_id()
app_1  |   File "/app/notifiers/telegram.py", line 111, in _get_chat_id
app_1  |     if int(update.message.text) == code:
app_1  | TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
tgtg_app_1 exited with code 1
```