### PR TITLE
Fixes problem with encoding of western characters

### DIFF
--- a/src/notifiers/webhook.py
+++ b/src/notifiers/webhook.py
@@ -35,7 +35,7 @@ class WebHook():
                 "Content-Type": self.type
             }
             if self.body:
-                body = item.unmask(self.body)
+                body = item.unmask(self.body).encode()
                 headers["Content-Length"] = str(len(body))
                 log.debug("Webhook body: %s", body)
             log.debug("Webhook headers: %s", headers)


### PR DESCRIPTION
This fixes a problem for me when webhooks responds containing a western letter inside `$${{display_name}}`. 

Western letter i.e. û or æ