### PR TITLE
fix: Add more granular logging to the project.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tornado==6.1
 tzdata==2022.5
 tzlocal==4.2
 urllib3==1.26.12
+colorlog==6.7.0

--- a/src/main.py
+++ b/src/main.py
@@ -74,12 +74,14 @@ def main() -> NoReturn:
     config_file = path.join(prog_folder, "config.ini")
     log_file = path.join(prog_folder, "scanner.log")
 
+    # Remove all handlers
     for handler in logging.root.handlers:
         logging.root.removeHandler(handler)
 
     logging.root.setLevel(logging.INFO)
-    formatter = colorlog.ColoredFormatter(
-        fmt="[%(cyan)s%(asctime)s%(reset)s][%(blue)s%(name)s%(reset)s][%(purple)s%(funcName)s%(reset)s][%(log_color)s%(levelname)s%(reset)s] - %(message)s",
+    # Define stream formatter and handler
+    stream_formatter = colorlog.ColoredFormatter(
+        fmt="[%(cyan)s%(asctime)s%(reset)s][%(log_color)s%(levelname)s%(reset)s] - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
         log_colors={
             "DEBUG": "purple",
@@ -90,10 +92,14 @@ def main() -> NoReturn:
         },
     )
     stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    logging.root.addHandler(logging.FileHandler(log_file, mode="w"))
+    stream_handler.setFormatter(stream_formatter)
+    # Define file formatter and handler
+    file_handler = logging.FileHandler(log_file, mode="w", encoding='utf-8')
+    file_formatter = logging.Formatter(fmt="[%(asctime)s][%(name)s][%(filename)s:%(funcName)s:%(lineno)d][%(levelname)s] - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    file_handler.setFormatter(file_formatter)
+    logging.root.addHandler(file_handler)
     logging.root.addHandler(stream_handler)
-
+    
     log = logging.getLogger("tgtg")
 
     config = Config(config_file) if path.isfile(config_file) else Config()

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from os import path
 from typing import NoReturn
 from packaging import version
 import requests
-
+import colorlog
 from scanner import Scanner
 from helper import Helper
 from models import Config
@@ -73,13 +73,29 @@ def main() -> NoReturn:
     )
     config_file = path.join(prog_folder, "config.ini")
     log_file = path.join(prog_folder, "scanner.log")
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)-8s %(message)s",
-        level=logging.INFO,
+
+    for handler in logging.root.handlers:
+        logging.root.removeHandler(handler)
+
+    logging.root.setLevel(logging.INFO)
+    formatter = colorlog.ColoredFormatter(
+        fmt="[%(cyan)s%(asctime)s%(reset)s][%(blue)s%(name)s%(reset)s][%(purple)s%(funcName)s%(reset)s][%(log_color)s%(levelname)s%(reset)s] - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        handlers=[logging.FileHandler(log_file, mode="w"), logging.StreamHandler()],
+        log_colors={
+            "DEBUG": "purple",
+            "INFO": "green",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "red",
+        },
     )
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logging.root.addHandler(logging.FileHandler(log_file, mode="w"))
+    logging.root.addHandler(stream_handler)
+
     log = logging.getLogger("tgtg")
+
     config = Config(config_file) if path.isfile(config_file) else Config()
     if config.debug or args.debug:
         # pylint: disable=E1103

--- a/src/main.py
+++ b/src/main.py
@@ -95,7 +95,7 @@ def main() -> NoReturn:
     stream_handler.setFormatter(stream_formatter)
     # Define file formatter and handler
     file_handler = logging.FileHandler(log_file, mode="w", encoding='utf-8')
-    file_formatter = logging.Formatter(fmt="[%(asctime)s][%(name)s][%(filename)s:%(funcName)s:%(lineno)d][%(levelname)s] - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    file_formatter = logging.Formatter(fmt="[%(asctime)s][%(name)s][%(filename)s:%(funcName)s:%(lineno)d][%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
     file_handler.setFormatter(file_formatter)
     logging.root.addHandler(file_handler)
     logging.root.addHandler(stream_handler)

--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,7 @@ def main() -> NoReturn:
     logging.root.setLevel(logging.INFO)
     # Define stream formatter and handler
     stream_formatter = colorlog.ColoredFormatter(
-        fmt="[%(cyan)s%(asctime)s%(reset)s][%(log_color)s%(levelname)s%(reset)s] - %(message)s",
+        fmt="%(cyan)s%(asctime)s%(reset)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
         log_colors={
             "DEBUG": "purple",


### PR DESCRIPTION
- Include timestamp, module name, function name and logging level.
- Add multiple colors for each information.

Example (The colors are not seen here):
```sh

[2022-11-26 19:19:19][tgtg][__init__][INFO] - Loaded config from config.ini
[2022-11-26 19:19:19][tgtg][main][INFO] - Debugging mode enabled
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] -   ____  ___  ____  ___    ____   ___   __   __ _  __ _  ____  ____  
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] -  (_  _)/ __)(_  _)/ __)  / ___) / __) / _\ (  ( \(  ( \(  __)(  _ \ 
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] -    )( ( (_ \  )( ( (_ \  \___ \( (__ /    \/    //    / ) _)  )   / 
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] -   (__) \___/ (__) \___/  (____/ \___)\_/\_/\_)__)\_)__)(____)(__\_) 
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] - 
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] - Version 1.14.0_rc1
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] - ©2022, Henning Merklinger
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] - For documentation and support please visit https://github.com/Der-Henning/tgtg
[2022-11-26 19:19:19][tgtg][_print_welcome_message][INFO] - 
[2022-11-26 19:19:19][urllib3.connectionpool][_new_conn][DEBUG] - Starting new HTTPS connection (1): api.github.com:443


```