### PR TITLE
Get WEBHOOK_BODY from env

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -346,6 +346,7 @@ class Config():
             self._env_get_boolean("WEBHOOK", "webhook.enabled")
             self._env_get("WEBHOOK_URL", "webhook.url")
             self._env_get("WEBHOOK_METHOD", "webhook.method")
+            self._env_get("WEBHOOK_BODY", "webhook.body")
             self._env_get("WEBHOOK_TYPE", "webhook.type")
             self._env_get_int("WEBHOOK_TIMEOUT", "webhook.timeout")
             self._env_get_cron("WEBHOOK_CRON", "webhook.cron")


### PR DESCRIPTION
There's a missing line of code to set webhook.body from the environment variables. At the moment, setting WEBHOOK_BODY does nothing, which is clearly a bug.