### PR TITLE
Proposal: Removed so the first test message is generated from a "rand…

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -42,8 +42,6 @@ class Scanner:
         items = sorted(self._get_favorites(),
                        key=lambda x: x.items_available,
                        reverse=True)
-        if items:
-            return items[0]
         items = sorted(
             [
                 Item(item)


### PR DESCRIPTION
Hi Henning,
It bothers me that if the service is restarted it always chooses the item from the given favorites, so when I receive a message I can not be sure if it is a actual message or the service was restarted (without checking my system). 
Removing those two lines did clear that up for me, so i guess this is the only thing that needs to be updated (for me).

Another proposal would be to add something like "Test-Message" to the first message after start.