### PR TITLE
Use humanize to completely handle natural days

### DIFF
--- a/tgtg_scanner/models/item.py
+++ b/tgtg_scanner/models/item.py
@@ -178,16 +178,10 @@ class Item:
         """
         if self.pickup_interval_start is None or self.pickup_interval_end is None:
             return "-"
-        now = datetime.datetime.now()
         pfr = self._datetimeparse(self.pickup_interval_start)
         pto = self._datetimeparse(self.pickup_interval_end)
         prange = f"{pfr.hour:02d}:{pfr.minute:02d} - {pto.hour:02d}:{pto.minute:02d}"
-        tommorow = now + datetime.timedelta(days=1)
-        if now.date() == pfr.date():
-            return f"{humanize.naturalday(now)}, {prange}"
-        if (pfr.date() - now.date()).days == 1:
-            return f"{humanize.naturalday(tommorow)}, {prange}"
-        return f"{pfr.day}/{pfr.month}, {prange}"
+        return f"{humanize.naturalday(pfr, format=f"{pfr.day}/{pfr.month})}, {prange}"
 
     def _get_distance_time(self, travel_mode: str) -> Union[DistanceTime, None]:
         if self.location is None:


### PR DESCRIPTION
This improves natural day formatting for the pickup time range:

1. Use natural day formatting for `yesterday` (in addition to `today` and `tomorrow`) -- this should only affect pickup time ranges that cross midnight
2. Remove the casework and let `humanize` handle it

<!-- markdownlint-disable-next-line MD041 -->
### Pull Request Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you make your Pull Request on the dev branch?
* [x] Does your submission pass tests? `make test`
* [x] Have you lint your code locally prior to submission? `make lint`
* [x] Could you build and run the docker images successfully? `make images`
* [x] Could you create a running executable? `make executable`
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran manual tests with your changes locally?
