### PR TITLE
Add support for multiple Pushsafer Device IDs

### DIFF
--- a/tgtg_scanner/models/config.py
+++ b/tgtg_scanner/models/config.py
@@ -203,13 +203,17 @@ class PushSaferConfig(NotifierConfig):
     """PushSafer Notifier configuration"""
 
     key: Union[str, None] = None
-    device_id: Union[str, None] = None
+    device_ids: list[str] = field(default_factory=list)
+
+    @property
+    def device_id(self) -> str | None:
+        return self.device_ids[0] if self.device_ids else None
 
     def _read_ini(self, parser: configparser.ConfigParser):
         self._ini_get_boolean(parser, "PUSHSAFER", "Enabled", "enabled")
         self._ini_get_cron(parser, "PUSHSAFER", "Cron", "cron")
         self._ini_get(parser, "PUSHSAFER", "Key", "key")
-        self._ini_get(parser, "PUSHSAFER", "DeviceID", "device_id")
+        self._ini_get_list(parser, "PUSHSAFER", "DeviceID", "device_ids")
 
     def _read_env(self):
         if environ.get("PUSH_SAFER", None):
@@ -226,8 +230,8 @@ class PushSaferConfig(NotifierConfig):
         self._env_get("PUSHSAFER_KEY", "key")
         if environ.get("PUSH_SAFER_DEVICE_ID", None):
             log.warning(DEPRECATION_NOTICE.format("PUSH_SAFER_DEVICE_ID", "PUSHSAFER_DEVICE_ID"))
-        self._env_get("PUSH_SAFER_DEVICE_ID", "device_id")
-        self._env_get("PUSHSAFER_DEVICE_ID", "device_id")
+        self._env_get_list("PUSH_SAFER_DEVICE_ID", "device_ids")
+        self._env_get_list("PUSHSAFER_DEVICE_ID", "device_ids")
 
 
 @dataclass

--- a/tgtg_scanner/notifiers/push_safer.py
+++ b/tgtg_scanner/notifiers/push_safer.py
@@ -22,10 +22,10 @@ class PushSafer(Notifier):
         super().__init__(config, reservations, favorites)
         self.enabled = config.pushsafer.enabled
         self.key = config.pushsafer.key
-        self.device_id = config.pushsafer.device_id
+        self.device_ids = config.pushsafer.device_ids
         self.cron = config.pushsafer.cron
         if self.enabled:
-            if self.key is None or self.device_id is None:
+            if self.key is None or self.device_ids is None:
                 raise PushSaferConfigurationError()
             self.client = Client(self.key)
 
@@ -33,7 +33,9 @@ class PushSafer(Notifier):
         """Sends item information to the Pushsafer endpoint"""
         if isinstance(item, Item):
             message = f"New Amount: {item.items_available}"
-            self.client.send_message(message, item.display_name, self.device_id)
+            if self.device_ids:
+                device_str = ",".join(self.device_ids)
+                self.client.send_message(message, item.display_name, device_str)
 
     def __repr__(self) -> str:
         return f"PushSafer: {self.key}"

--- a/tgtg_scanner/notifiers/push_safer.py
+++ b/tgtg_scanner/notifiers/push_safer.py
@@ -33,9 +33,8 @@ class PushSafer(Notifier):
         """Sends item information to the Pushsafer endpoint"""
         if isinstance(item, Item):
             message = f"New Amount: {item.items_available}"
-            if self.device_ids:
-                device_str = ",".join(self.device_ids)
-                self.client.send_message(message, item.display_name, device_str)
+            for device_id in self.device_ids:
+                self.client.send_message(message, item.display_name, device_id)
 
     def __repr__(self) -> str:
         return f"PushSafer: {self.key}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
### Pull Request Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you make your Pull Request on the dev branch?
* [x] Does your submission pass tests? `make test`
* [x] Have you lint your code locally prior to submission? `make lint`
* [x] Could you build and run the docker images successfully? `make images`
* [x] Could you create a running executable? `make executable`
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran manual tests with your changes locally?

### Description

This PR introduces support for notifying multiple Pushsafer devices by allowing a comma-separated list in the `PUSHSAFER_DEVICE_ID` environment variable.

**Changes include:**
- `PushSaferConfig.device_ids` now accepts a list of device IDs via `.env` or INI.
- ~~Message dispatch uses `join()` internally to send one message to multiple recipients in a single API call.~~
- Message dispatch now loops over `device_ids` to send one message per device via individual API calls, since Pushsafer does not support sending to multiple devices in a single call.
- Legacy `device_id` is still accessible via `.device_id` for backward compatibility.

**Why:**
To allow multiple users (e.g., neighbors without tech knowledge) to receive notifications for common favorites, without needing to run separate instances.
